### PR TITLE
Refactor mode and command stuff and fix bug

### DIFF
--- a/http/code.js
+++ b/http/code.js
@@ -77,7 +77,6 @@ var toggle_monitoring_mode = function() {
     scraperwiki.exec('MODE=' + new_mode + ' tool/twsearch.py change-mode',
         function(data) {
             $checkbox.show().next().hide()
-            done_exec_main(data)
         },
         function(obj, err, exception) {
             something_went_wrong(err + "! " + exception)

--- a/http/code.js
+++ b/http/code.js
@@ -176,7 +176,7 @@ var show_hide_stuff = function(done, rename) {
         }
 
         // Show right form
-        scraperwiki.sql('select *, (select mode from __mode where id ="tweets") from __status where id = "tweets"', function(results){
+        scraperwiki.sql('select *, (select mode from __mode where id ="tweets") as mode from __status where id = "tweets"', function(results){
             results = results[0]
             console.log(results)
 
@@ -214,7 +214,7 @@ var show_hide_stuff = function(done, rename) {
                 scraperwiki.dataset.name("Tweets matching '" + data + "'")
             } else if (results['current_status'] == 'ok-updating') {
                 scraperwiki.exec("crontab -l", function(text) {
-                    if (mode == 'clearing-backlog' && text.match(/no crontab/)) {
+                    if (results['mode'] == 'clearing-backlog' && text.match(/no crontab/)) {
                         results['mode'] = 'backlog-cleared'
                     }
                     $("#schedule-button").removeClass("loading")

--- a/http/code.js
+++ b/http/code.js
@@ -74,7 +74,7 @@ var toggle_monitoring_mode = function() {
     var $checkbox = $(this)
     $checkbox.hide().next().show()
 
-    scraperwiki.exec('MODE=' + new_mode + ' tool/twsearch.py "' + callback_url + '" "' + oauth_verifier + '"',
+    scraperwiki.exec('MODE=' + new_mode + ' tool/twsearch.py change-mode',
         function(data) {
             $checkbox.show().next().hide()
             done_exec_main(data)

--- a/http/code.js
+++ b/http/code.js
@@ -210,7 +210,7 @@ var show_hide_stuff = function(done, rename) {
                 } else {
                     $('#settings-auth').show()
                     $('#settings-clear').show()
-        }
+                }
                 // Rename the dataset in the user interface
                 scraperwiki.dataset.name("Tweets matching '" + data + "'")
             } else if (results['current_status'] == 'ok-updating') {

--- a/http/code.js
+++ b/http/code.js
@@ -75,8 +75,9 @@ var toggle_monitoring_mode = function() {
     $checkbox.hide().next().show()
 
     scraperwiki.exec('MODE=' + new_mode + ' tool/twsearch.py change-mode',
-        function(data) {
+        function(content) {
             $checkbox.show().next().hide()
+            done_exec_main(content, false)
         },
         function(obj, err, exception) {
             something_went_wrong(err + "! " + exception)

--- a/http/code.js
+++ b/http/code.js
@@ -193,7 +193,7 @@ var show_hide_stuff = function(done, rename) {
             if (results['current_status'] == 'clean-slate') {
                 $('#settings-get').show()
             } else if (results['current_status'] == 'invalid-query') {
-        console.log(results)
+                console.log(results)
                 var p = $('<p>').addClass('alert alert-warning').html("<b>That query didn't work!</b> It isn't a valid Twitter search.")
                 $('body').prepend(p)
                 $('#settings-get').show()

--- a/http/code.js
+++ b/http/code.js
@@ -176,7 +176,7 @@ var show_hide_stuff = function(done, rename) {
         }
 
         // Show right form
-        scraperwiki.sql('select *, (select * from __modes where id ="tweets") from __status where id = "tweets"', function(results){
+        scraperwiki.sql('select *, (select mode from __mode where id ="tweets") from __status where id = "tweets"', function(results){
             results = results[0]
             console.log(results)
 

--- a/http/code.js
+++ b/http/code.js
@@ -177,7 +177,7 @@ var show_hide_stuff = function(done, rename) {
         }
 
         // Show right form
-        scraperwiki.sql('select * from __status where id = "tweets"', function(results){
+        scraperwiki.sql('select *, (select * from __modes where id ="tweets") from __status where id = "tweets"', function(results){
             results = results[0]
             console.log(results)
 

--- a/http/code.js
+++ b/http/code.js
@@ -74,7 +74,7 @@ var toggle_monitoring_mode = function() {
     var $checkbox = $(this)
     $checkbox.hide().next().show()
 
-    scraperwiki.exec('MODE=' + new_mode + ' ONETIME=1 tool/twsearch.py "' + callback_url + '" "' + oauth_verifier + '"',
+    scraperwiki.exec('MODE=' + new_mode + ' tool/twsearch.py "' + callback_url + '" "' + oauth_verifier + '"',
         function(data) {
             $checkbox.show().next().hide()
             done_exec_main(data)

--- a/twsearch.py
+++ b/twsearch.py
@@ -276,7 +276,7 @@ def command_scrape():
             # happens when '__mode' table doesn't exist
             mode = 'clearing-backlog'
     log("initial mode = {!r}".format(mode))
-    assert mode in ['clearing-backlog', 'backlog-cleared', 'monitoring'] # should never happen
+    assert mode in ['clearing-backlog', 'monitoring'] # should never happen
 
     # Read window from database
     try:
@@ -305,11 +305,6 @@ def command_scrape():
 
         # Connect to Twitter
         tw = do_tool_oauth()
-
-        # Mode changes
-        if mode == 'backlog-cleared':
-            # we shouldn't run, because we've cleared the backlog already
-            set_status_and_exit("ok-updating", 'ok', '')
 
         # crontab to schedule for next time
         # we make a new crontab file, with random minute do distribute load for platform
@@ -352,9 +347,8 @@ def command_scrape():
             window_start = scraperwiki.sql.select("max(created_at) from tweets")[0]["max(id_str)"]
             change_window(window_start, None)
 
-        # We've reached as far back as we'll ever get, so we're done forever in one mode
+        # We've reached as far back as we'll ever get, so we're done forever stop the crontab
         if not onetime and mode == 'clearing-backlog':
-            change_mode('backlog-cleared')
             os.system("crontab -r >/dev/null 2>&1")
             set_status_and_exit("ok-updating", 'ok', '')
 

--- a/twsearch.py
+++ b/twsearch.py
@@ -315,29 +315,29 @@ try:
         log("new window_end = {!r}".format(window_end))
 
     if window_end != None:
-      # Go backwards from current window_end until we've got all we can
-      #
-      # Loop termination: Note that we search with max_id set to the id of some
-      # tweet that we have already saved, which means we'll get that tweet in our
-      # results, which means that we only have _new_ tweets if the number that we
-      # got is bigger than 1.
-      got = 2
-      while got > 1:
-          log("backwards q = {!r} since_id/window_start = {!r} max_id/window_end = {!r}".format(query_terms, window_start, window_end))
-          if window_end == None:
-            # for some reason can't just pass max_id in as None
-            results = tw.search.tweets(q=query_terms, result_type = 'recent', since_id = window_start)
-          else:
-            results = tw.search.tweets(q=query_terms, result_type = 'recent', max_id = window_end, since_id = window_start)
-          got = process_results(results, query_terms)
-          log("   got backwards {}".format(got))
-          if got > 0:
-            window_end = str(min(x['id'] for x in results['statuses']))
-          log("new window_end = {!r}".format(window_end))
+        # Go backwards from current window_end until we've got all we can
+        #
+        # Loop termination: Note that we search with max_id set to the id of some
+        # tweet that we have already saved, which means we'll get that tweet in our
+        # results, which means that we only have _new_ tweets if the number that we
+        # got is bigger than 1.
+        got = 2
+        while got > 1:
+            log("backwards q = {!r} since_id/window_start = {!r} max_id/window_end = {!r}".format(query_terms, window_start, window_end))
+            if window_end == None:
+              # for some reason can't just pass max_id in as None
+              results = tw.search.tweets(q=query_terms, result_type = 'recent', since_id = window_start)
+            else:
+              results = tw.search.tweets(q=query_terms, result_type = 'recent', max_id = window_end, since_id = window_start)
+            got = process_results(results, query_terms)
+            log("   got backwards {}".format(got))
+            if got > 0:
+              window_end = str(min(x['id'] for x in results['statuses']))
+            log("new window_end = {!r}".format(window_end))
 
-          pages_got += 1
-          if onetime:
-              break
+            pages_got += 1
+            if onetime:
+                break
 
       # Update the window, it now starts from our latest place forward
       if not onetime:

--- a/twsearch.py
+++ b/twsearch.py
@@ -254,6 +254,17 @@ def command_diagnostics():
     sys.exit()
 
 def command_scrape():
+    # Make sure this scrape mode only runs once at once
+    f = open("query.txt")
+    try:
+        fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except IOError:
+        log("already running scrape according to flock, exiting")
+        sys.exit()
+
+    # Get query we're working on from file we store it in
+    query_terms = codecs.open("query.txt", "r", "utf-8").read().strip()
+
     # Read mode from database
     try:
         mode = scraperwiki.sql.select('mode from __mode')[0]['mode']
@@ -293,9 +304,6 @@ def command_scrape():
         # Make the tweets table *first* with dumb data, calling DumpTruck directly,
         # so it appears before the status one in the list
         scraperwiki.sql.dt.create_table({'id_str': '1'}, 'tweets')
-
-        # Get query we're working on from file we store it in
-        query_terms = codecs.open("query.txt", "r", "utf-8").read().strip()
 
         # Connect to Twitter
         tw = do_tool_oauth()

--- a/twsearch.py
+++ b/twsearch.py
@@ -209,11 +209,12 @@ onetime = 'ONETIME' in os.environ
 
 command = 'scrape'
 if len(sys.argv) > 1:
-    if sys.argv[1] in ('diagnostics', 'clean-slate'):
+    if sys.argv[1] in ('diagnostics', 'clean-slate', 'change-mode'):
         command = sys.argv[1]
 
 # Just change the mode, then stop
-if 'MODE' in os.environ:
+if command == 'change-mode':
+    assert 'MODE' in os.environ
     mode = os.environ['MODE']
     change_mode(mode)
     just_exit()

--- a/twsearch.py
+++ b/twsearch.py
@@ -294,17 +294,17 @@ def command_scrape(mode):
 
     # Read window from database
     try:
-      window_start = scraperwiki.sql.select('window_start from __window')[0]['window_start']
+      window_start = str(scraperwiki.sql.select('window_start from __window')[0]['window_start'])
     except sqlite3.OperationalError:
       try:
-        window_start = scraperwiki.sql.select('window_start from __status')[0]['window_start']
+        window_start = str(scraperwiki.sql.select('window_start from __status')[0]['window_start'])
       except sqlite3.OperationalError:
         window_start = None
     try:
-      window_end = scraperwiki.sql.select('window_end from __window')[0]['window_end']
+      window_end = str(scraperwiki.sql.select('window_end from __window')[0]['window_end'])
     except sqlite3.OperationalError:
       try:
-        window_end = scraperwiki.sql.select('window_end from __status')[0]['window_end']
+        window_end = str(scraperwiki.sql.select('window_end from __status')[0]['window_end'])
       except sqlite3.OperationalError:
         window_end = None
     log("initial window = {!r} - {!r}".format(window_start, window_end))
@@ -351,7 +351,9 @@ def command_scrape(mode):
 
         # Update the window, it now starts from most recent place forward (i.e. window_end is None)
         if not onetime:
-            window_start = scraperwiki.sql.select("max(cast(id_str as integer)) as max_id from tweets")[0]["max_id"]
+            # The double cast here is so SQLite correctly sorts id_str as if it were and integer not a string,
+            # yet we still return a string
+            window_start = str(scraperwiki.sql.select("max(cast(id_str as integer)) as max_id from tweets")[0]["max_id"])
             change_window(window_start, None)
 
         # Get the mode again, in case the user has meanwhile changed it by clicking "Monitor future tweets"

--- a/twsearch.py
+++ b/twsearch.py
@@ -148,7 +148,7 @@ def change_mode(new_mode):
 # The range of Tweets we're currently fetching, from end backwards
 def change_window(start, end):
     scraperwiki.sql.save(['id'], { 'id': 'tweets', 'window_start': start, 'window_end': end }, table_name='__window')
-    log("new window! window_start = {!r} window_end = {!r}".format(start, end))
+    log("new window! window = {!r} - {!r}".format(start, end))
 
 def process_results(results, query_terms):
     datas = []
@@ -283,7 +283,7 @@ def command_scrape():
         window_end = scraperwiki.sql.select('window_end from __status')[0]['window_end']
       except sqlite3.OperationalError:
         window_end = None
-    log("initial window_start = {!r} window_end = {!r}".format(window_start, window_end))
+    log("initial window = {!r} - {!r}".format(window_start, window_end))
 
     pages_got = 0
     onetime = 'ONETIME' in os.environ
@@ -320,7 +320,7 @@ def command_scrape():
         # got is bigger than 1.
         got = 2
         while got > 1:
-            log("q = {!r} window_start = {!r} window_end = {!r}".format(query_terms, window_start, window_end))
+            log("q = {!r} window = {!r} - {!r}".format(query_terms, window_start, window_end))
             if window_end == None:
               log("    jumping forwards")
               # for some reason can't just pass max_id in as None

--- a/twsearch.py
+++ b/twsearch.py
@@ -124,12 +124,6 @@ def clear_auth_and_restart():
 #########################################################################
 # Helper functions
 
-# Just print the return code, don't update status database table
-def just_exit(extra = {}):
-    extra['status'] = status
-    print json.dumps(extra)
-    sys.exit()
-
 # Signal back to the calling Javascript, to the database, and custard's status API, our status
 def set_status_and_exit(status, typ, message, extra = {}):
     requests.post("https://scraperwiki.com/api/status", data={'type':typ, 'message':message})
@@ -139,7 +133,9 @@ def set_status_and_exit(status, typ, message, extra = {}):
 
     log("set_status_and_exit status={!r}, type={!r}, message={!r}".format(status, typ, message))
 
-    just_exit()
+    extra['status'] = status
+    print json.dumps(extra)
+    sys.exit()
 
 # Either we or the user is changing the mode explicitly
 def change_mode(new_mode):
@@ -210,7 +206,8 @@ def command_change_mode():
     assert 'MODE' in os.environ
     mode = os.environ['MODE']
     change_mode(mode)
-    just_exit()
+    print json.dumps({'mode-changed': 'ok'})
+    sys.exit()
 
 # Clean everything, as if the tool was new
 def command_clean_state():

--- a/twsearch.py
+++ b/twsearch.py
@@ -355,7 +355,7 @@ def command_scrape(mode):
             change_window(window_start, None)
 
         # Get the mode again, in case the user has meanwhile changed it by clicking "Monitor future tweets"
-        mode = get_mode():
+        mode = get_mode()
         if not onetime and mode == 'clearing-backlog':
             # We've reached as far back as we'll ever get, so we're done forever stop the crontab
             os.system("crontab -r >/dev/null 2>&1")

--- a/twsearch.py
+++ b/twsearch.py
@@ -195,8 +195,8 @@ def process_results(results, query_terms):
         datas.append(data)
 
     if datas:
-        min_id = min(x['id_str'] for x in datas)
-        max_id = max(x['id_str'] for x in datas)
+        min_id = min(int(x['id_str']) for x in datas)
+        max_id = max(int(x['id_str']) for x in datas)
         log("about to save; min_id {}, max_id {}".format(min_id, max_id))
     else:
         log("no datas")
@@ -343,7 +343,7 @@ def command_scrape():
 
         # Update the window, it now starts from most recent place forward (i.e. window_end is None)
         if not onetime:
-            window_start = scraperwiki.sql.select("max(id_str) from tweets")[0]["max(id_str)"]
+            window_start = scraperwiki.sql.select("max(created_at) from tweets")[0]["max(id_str)"]
             change_window(window_start, None)
 
         # We've reached as far back as we'll ever get, so we're done forever in one mode

--- a/twsearch.py
+++ b/twsearch.py
@@ -310,7 +310,7 @@ def command_scrape():
         # Jump window end forwards once to the most recent Tweet (if we don't
         # already have an end we are working backwards from)
         if window_end == None:
-            log("forwards q = {!r} since_id/window_start = {!r} max_id/window_end = {!r}".format(query_terms, window_start, window_end))
+            log("forwards q = {!r} window_start = {!r} window_end = {!r}".format(query_terms, window_start, window_end))
             results = tw.search.tweets(q=query_terms, result_type = 'recent', since_id = window_start)
             got = process_results(results, query_terms)
             log("   got forwards {}".format(got))
@@ -327,7 +327,7 @@ def command_scrape():
             # got is bigger than 1.
             got = 2
             while got > 1:
-                log("backwards q = {!r} since_id/window_start = {!r} max_id/window_end = {!r}".format(query_terms, window_start, window_end))
+                log("backwards q = {!r} window_start = {!r} window_end = {!r}".format(query_terms, window_start, window_end))
                 if window_end == None:
                   # for some reason can't just pass max_id in as None
                   results = tw.search.tweets(q=query_terms, result_type = 'recent', since_id = window_start)
@@ -347,7 +347,7 @@ def command_scrape():
           if not onetime:
             window_start = scraperwiki.sql.select("max(id_str) from tweets")[0]["max(id_str)"]
             window_end = None
-            log("new window! since_id/window_start = {!r} max_id/window_end = {!r}".format(window_start, window_end))
+            log("new window! window_start = {!r} window_end = {!r}".format(window_start, window_end))
 
         # We've reached as far back as we'll ever get, so we're done forever in one mode
         if not onetime and mode == 'clearing-backlog':

--- a/twsearch.py
+++ b/twsearch.py
@@ -258,8 +258,8 @@ def command_diagnostics():
     diagnostics['mode'] = modes['mode']
 
     windows = scraperwiki.sql.select('* from __window')[0]
-    diagnostics['window_start'] = windows['window_start']
-    diagnostics['window_end'] = windows['window_end']
+    diagnostics['window_start'] = windows.get('window_start', None)
+    diagnostics['window_end'] = windows.get('window_end', None)
 
     crontab = subprocess.check_output("crontab -l | grep twsearch.py; true", stderr=subprocess.STDOUT, shell=True)
     diagnostics['crontab'] = crontab
@@ -346,7 +346,7 @@ def command_scrape(mode):
 
         # Update the window, it now starts from most recent place forward (i.e. window_end is None)
         if not onetime:
-            window_start = scraperwiki.sql.select("max(created_at) from tweets")[0]["max(id_str)"]
+            window_start = scraperwiki.sql.select("max(cast(id_str as integer)) as max_id from tweets")[0]["max_id"]
             change_window(window_start, None)
 
         # We've reached as far back as we'll ever get, so we're done forever stop the crontab

--- a/twsearch.py
+++ b/twsearch.py
@@ -279,6 +279,12 @@ def command_diagnostics():
     print json.dumps(diagnostics)
     sys.exit()
 
+# Make something a string, without casting None to string
+def make_sure_string(var):
+    if var == None:
+        return var
+    return str(var)
+
 def command_scrape(mode):
     # Make sure this scrape mode only runs once at once
     f = open("query.txt")
@@ -294,17 +300,17 @@ def command_scrape(mode):
 
     # Read window from database
     try:
-      window_start = str(scraperwiki.sql.select('window_start from __window')[0]['window_start'])
+      window_start = make_sure_string(scraperwiki.sql.select('window_start from __window')[0]['window_start'])
     except sqlite3.OperationalError:
       try:
-        window_start = str(scraperwiki.sql.select('window_start from __status')[0]['window_start'])
+        window_start = make_sure_string(scraperwiki.sql.select('window_start from __status')[0]['window_start'])
       except sqlite3.OperationalError:
         window_start = None
     try:
-      window_end = str(scraperwiki.sql.select('window_end from __window')[0]['window_end'])
+      window_end = make_sure_string(scraperwiki.sql.select('window_end from __window')[0]['window_end'])
     except sqlite3.OperationalError:
       try:
-        window_end = str(scraperwiki.sql.select('window_end from __status')[0]['window_end'])
+        window_end = make_sure_string(scraperwiki.sql.select('window_end from __status')[0]['window_end'])
       except sqlite3.OperationalError:
         window_end = None
     log("initial window = {!r} - {!r}".format(window_start, window_end))
@@ -342,7 +348,7 @@ def command_scrape(mode):
             log("    got {}".format(got))
 
             if got > 0:
-              window_end = str(min(x['id'] for x in results['statuses']))
+              window_end = make_sure_string(min(x['id'] for x in results['statuses']))
               change_window(window_start, window_end)
 
             pages_got += 1
@@ -353,7 +359,7 @@ def command_scrape(mode):
         if not onetime:
             # The double cast here is so SQLite correctly sorts id_str as if it were and integer not a string,
             # yet we still return a string
-            window_start = str(scraperwiki.sql.select("max(cast(id_str as integer)) as max_id from tweets")[0]["max_id"])
+            window_start = make_sure_string(scraperwiki.sql.select("max(cast(id_str as integer)) as max_id from tweets")[0]["max_id"])
             change_window(window_start, None)
 
         # Get the mode again, in case the user has meanwhile changed it by clicking "Monitor future tweets"

--- a/twsearch.py
+++ b/twsearch.py
@@ -269,6 +269,7 @@ def command_scrape():
     log("initial mode = {!r}".format(mode))
     assert mode in ['clearing-backlog', 'backlog-cleared', 'monitoring'] # should never happen
 
+    # Read window from database
     try:
       window_start = scraperwiki.sql.select('window_start from __window')[0]['window_start']
     except sqlite3.OperationalError:
@@ -285,9 +286,9 @@ def command_scrape():
         window_end = None
     log("initial window = {!r} - {!r}".format(window_start, window_end))
 
-    pages_got = 0
     onetime = 'ONETIME' in os.environ
 
+    pages_got = 0
     try:
         # Make the tweets table *first* with dumb data, calling DumpTruck directly,
         # so it appears before the status one in the list

--- a/twsearch.py
+++ b/twsearch.py
@@ -238,8 +238,8 @@ def command_diagnostics():
 
     statuses = scraperwiki.sql.select('* from __status')[0]
     diagnostics['status'] = statuses['current_status']
-    diagnostics['window_start'] = window_start
-    diagnostics['window_end'] = window_end
+    diagnostics['window_start'] = statuses['window_start']
+    diagnostics['window_end'] = statuses['window_end']
 
     modes = scraperwiki.sql.select('* from __mode')[0]
     diagnostics['mode'] = modes['mode']

--- a/twsearch.py
+++ b/twsearch.py
@@ -207,6 +207,11 @@ def process_results(results, query_terms):
 pages_got = 0
 onetime = 'ONETIME' in os.environ
 
+command = 'scrape'
+if len(sys.argv) > 1:
+    if sys.argv[1] in ('diagnostics', 'clean-slate'):
+        command = sys.argv[1]
+
 # Just change the mode, then stop
 if 'MODE' in os.environ:
     mode = os.environ['MODE']
@@ -243,7 +248,7 @@ try:
     #   a. None: try and scrape Twitter followers
     #   b. callback_url oauth_verifier: have just come back from Twitter with these oauth tokens
     #   c. "clean-slate": wipe database and start again
-    if len(sys.argv) > 1 and sys.argv[1] == 'clean-slate':
+    if command == 'clean-slate':
         scraperwiki.sql.execute("drop table if exists tweets")
         scraperwiki.sql.execute("drop table if exists __status")
         os.system("crontab -r >/dev/null 2>&1")
@@ -265,7 +270,7 @@ try:
     tw = do_tool_oauth()
 
     # Called for diagnostic information only
-    if len(sys.argv) > 1 and sys.argv[1] == 'diagnostics':
+    if command == 'diagnostics':
         diagnostics = {}
         diagnostics['_rate_limit_status'] = tw.application.rate_limit_status()
         diagnostics['limit'] = diagnostics['_rate_limit_status']['resources']['search']['/search/tweets']['limit']

--- a/twsearch.py
+++ b/twsearch.py
@@ -19,6 +19,26 @@ import codecs
 
 from secrets import *
 
+# Horrendous hack to work around some Twitter / Python incompatibility
+# http://bobrochel.blogspot.co.nz/2010/11/bad-servers-chunked-encoding-and.html
+def patch_http_response_read(func):
+    def inner(*args):
+        try:
+            return func(*args)
+        except httplib.IncompleteRead, e:
+            return e.partial
+    return inner
+httplib.HTTPResponse.read = patch_http_response_read(httplib.HTTPResponse.read)
+
+# Make sure you install this version of "twitter":
+# http://pypi.python.org/pypi/twitter
+# http://mike.verdone.ca/twitter/
+# https://github.com/sixohsix/twitter
+import twitter
+
+#########################################################################
+# Logging
+
 logf = open(os.path.expanduser("~/all.log"), 'a', buffering=1)
 
 def log(message):
@@ -32,7 +52,6 @@ def log(message):
 
     logf.write("{} {} {}\n".format(timestamp, pid, message))
 
-
 def on_exit():
     log("exiting (via atexit)")
 
@@ -42,24 +61,6 @@ log("started with arguments: {!r}".format(sys.argv))
 log("started with environ: ONETIME={!r}, MODE={!r}".format(
   os.environ.get("ONETIME"),
   os.environ.get("MODE")))
-
-# Horrendous hack to work around some Twitter / Python incompatibility
-# http://bobrochel.blogspot.co.nz/2010/11/bad-servers-chunked-encoding-and.html
-def patch_http_response_read(func):
-    def inner(*args):
-        try:
-            return func(*args)
-        except httplib.IncompleteRead, e:
-            return e.partial
-
-    return inner
-httplib.HTTPResponse.read = patch_http_response_read(httplib.HTTPResponse.read)
-
-# Make sure you install this version of "twitter":
-# http://pypi.python.org/pypi/twitter
-# http://mike.verdone.ca/twitter/
-# https://github.com/sixohsix/twitter
-import twitter
 
 #########################################################################
 # Authentication to Twitter

--- a/twsearch.py
+++ b/twsearch.py
@@ -170,11 +170,9 @@ def process_results(results, query_terms):
         data['in_reply_to_screen_name'] = tweet['in_reply_to_screen_name']
         data['in_reply_to_status_id'] = tweet['in_reply_to_status_id']
 
-        try:
+        if 'geo' in tweet and 'coordinates' in tweet['geo']:
             data['lat'] = tweet['geo']['coordinates'][0]
             data['lng'] = tweet['geo']['coordinates'][1]
-        except:
-            pass
 
         entities = tweet.get('entities', {})
 

--- a/twsearch.py
+++ b/twsearch.py
@@ -185,7 +185,7 @@ def process_results(results, query_terms):
         data['in_reply_to_screen_name'] = tweet['in_reply_to_screen_name']
         data['in_reply_to_status_id'] = tweet['in_reply_to_status_id']
 
-        if 'geo' in tweet and 'coordinates' in tweet['geo']:
+        if 'geo' in tweet and tweet['geo'] != None and 'coordinates' in tweet['geo']:
             data['lat'] = tweet['geo']['coordinates'][0]
             data['lng'] = tweet['geo']['coordinates'][1]
 

--- a/twsearch.py
+++ b/twsearch.py
@@ -16,6 +16,7 @@ import scraperwiki
 import httplib
 import random
 import codecs
+import fcntl
 
 from secrets import *
 


### PR DESCRIPTION
This is very much still in progress, pull request just for review as I go along.

Ultimate aim is to fix https://github.com/scraperwiki/twitter-search-tool/issues/19, am taking chance to refactor code.
- [x] Get rid of global variables in twsearch.py
- [x] Split main code into obvious functions (one for clear data, set mode, set crontab, diagnostics)
- [x] Make mode setting do nothing else but update the mode field in database and exit
- [x] Add flock or similar to stop main scrape part running twice concurrently
- [x] Fix the actual original bug (remove backlog-cleared mode)
- [x] Doesn't make the crontab when you restart monitoring
- [x] Truncation of max_id (some id_str badness)
- [x] Make sure Javascript reads mode correctly
- [x] UI shows wrong thing when first converted to new code, without running twsearch.py
- [x] Actually test it all
- [x] Notify this user when it works https://app.intercom.io/apps/63b0c6d4bb5f0867b6e93b0be9b569fb3a7ab1e3/conversations/363013245
